### PR TITLE
fix: use Process.platform for iOS detection instead of Swift.available

### DIFF
--- a/disable-flutter-tls.js
+++ b/disable-flutter-tls.js
@@ -120,7 +120,7 @@ function disableTLSValidation() {
     if(Java.available){
         platformConfig = config["android"]
     }
-    else if(Java.available || Swift.available){
+    else if(Process.platform === 'darwin'){
         platformConfig = config["ios"]
     }
     else if(Process.platform in config){


### PR DESCRIPTION
The script currently uses `Swift.available` to detect iOS, but this can fail if the Swift bridge crashes during initialization, leaving `Swift` as `undefined`:

**Before (Frida 17.9.1):**
```
[+] Arch: arm64
[+] Platform:  darwin
[ ] Locating Flutter library 1/5
Error: access violation accessing 0x267bdeb81
    at get flags (/frida/bridges/swift.js:1)
    at getModuleContext (/frida/bridges/swift.js:1)
    at getFullTypeName (/frida/bridges/swift.js:1)
TypeError: cannot read property 'available' of undefined
    at disableTLSValidation (disable-flutter-tls.js:123)
```

**After:**
```
[+] Arch: arm64
[+] Platform:  darwin
[ ] Locating Flutter library 1/5
[+] Flutter library located
[+] ssl_verify_peer_cert found at offset: 0x3b91a8 (0x3b91a8)
[+] ssl_verify_peer_cert has been patched
```

**Change:** Replace `Swift.available` with `Process.platform === 'darwin'` on line 123, which doesn't depend on the Swift runtime being available in the target process.

**Test environment:**
- iPhone X (iOS 16.7.14)
- Frida 17.9.1
- NVISO Flutter pinning demo app (`eu.nviso.flutterPinning`)